### PR TITLE
Specify C++ version to 17

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,2 +1,3 @@
 build --symlink_prefix=bzl-build/
 build --explain=bzl-build/explain.log --verbose_explanations
+build --action_env=BAZEL_CXXOPTS="-std=c++17"


### PR DESCRIPTION
We should be using C++17, as some features we have don't work without it.
